### PR TITLE
Remove unnecessary storeObjectAttribute code

### DIFF
--- a/datatypes/mugorecurringevent/mugorecurringeventtype.php
+++ b/datatypes/mugorecurringevent/mugorecurringeventtype.php
@@ -24,9 +24,6 @@ class MugoRecurringEventType extends eZDataType
      */
     function storeObjectAttribute( $contentObjectAttribute )
     {
-        $content = $contentObjectAttribute->content();
-        $contentObjectAttribute->setAttribute( 'data_text', $content );
-
         return true;
     }
 

--- a/datatypes/mugorecurringevent/mugorecurringeventtype.php
+++ b/datatypes/mugorecurringevent/mugorecurringeventtype.php
@@ -127,14 +127,6 @@ class MugoRecurringEventType extends eZDataType
                 }
             }
         }
-        else
-        {
-            $contentObjectAttribute->setContent(
-                $contentObjectAttribute->attribute( 'id' ) .
-                '_' .
-                $contentObjectAttribute->attribute( 'version' )
-            );
-        }
 
         return true;
     }

--- a/datatypes/mugorecurringevent/mugorecurringeventtype.php
+++ b/datatypes/mugorecurringevent/mugorecurringeventtype.php
@@ -374,12 +374,6 @@ class MugoRecurringEventType extends eZDataType
             {
                 $mugoCalendarPersistentObject->store();
             }
-            // Store a reference to the entry in the calendar table
-            $contentObjectAttribute->setContent(
-                $contentObjectAttribute->attribute( 'id' ) .
-                '_' .
-                $contentObjectAttribute->attribute( 'version' )
-            );
         }
 
         return true;


### PR DESCRIPTION
Event data is stored in a separate table. The raw result from $contentObjectAttribute->content() (which is a wrapper for $dataType->objectAttributeContent() when the content has not already been set in the request) is incompatible with DB storage as it's an array, and we do not use the contents of "data_text" for anything -- it's currently containing redundant information. When it is trying to set an array, this produces an error on PHP 8.